### PR TITLE
Add fallow to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,4 @@ Read [how to write your own langauge service plugin here](https://github.com/Mic
 - [typescript-json-schema](https://github.com/YousefED/typescript-json-schema) - Generate json-schema from your TypeScript sources
 - [ts-json-schema-generator](https://github.com/vega/ts-json-schema-generator) - Generate JSON schema from your TypeScript sources
 - [ts-query](https://github.com/phenomnomnominal/tsquery) - TypeScript AST query library
+- [fallow](https://github.com/fallow-rs/fallow) - Finds dead code, duplication, circular dependencies, and complexity hotspots in TypeScript codebases


### PR DESCRIPTION
Adds fallow to the Tools section. fallow statically analyzes TypeScript and JavaScript codebases for unused files, exports, and dependencies, plus duplication, circular dependencies, and complexity hotspots. Built on the Oxc parser ecosystem with zero-config framework detection.

Repo: https://github.com/fallow-rs/fallow
Docs: https://docs.fallow.tools

- Actively maintained, 380+ stars, 5 contributors
- MIT licensed
- Written in Rust