### PR TITLE
Add jsontosdk to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,4 @@ Read [how to write your own langauge service plugin here](https://github.com/Mic
 - [ts-json-schema-generator](https://github.com/vega/ts-json-schema-generator) - Generate JSON schema from your TypeScript sources
 - [ts-query](https://github.com/phenomnomnominal/tsquery) - TypeScript AST query library
 - [fallow](https://github.com/fallow-rs/fallow) - Finds dead code, duplication, circular dependencies, and complexity hotspots in TypeScript codebases
+- [jsontosdk](https://github.com/SolvoHQ/jsontosdk) - Paste a JSON sample and generate typed TypeScript interfaces, a Zod schema, and a fetch helper


### PR DESCRIPTION
Adds [jsontosdk](https://github.com/SolvoHQ/jsontosdk) to the Tools section.

It's a JSON-to-TypeScript code generator: paste a JSON sample (e.g. an API response) and it emits a typed TS interface, a matching Zod schema, and a fetch helper. Sits alongside the existing `typescript-json-schema` / `ts-json-schema-generator` peers — same neighborhood, opposite direction (JSON → TS instead of TS → JSON Schema).

Live at https://jsontosdk.vercel.app, MIT-licensed.